### PR TITLE
Specify the version to make sure the test targets the right blueprint

### DIFF
--- a/catalog.tests.bom
+++ b/catalog.tests.bom
@@ -25,7 +25,7 @@ brooklyn.catalog:
     name: Three tier webapp Test
     item:
       services:
-      - type: ThreeTierApp
+      - type: ThreeTierApp:0.0.1-SNAPSHOT
         id: target-app
         brooklyn.config:
           ssl:


### PR DESCRIPTION
This is to avoid using another `ThreeTierApp` blueprint that could be already registered within the Brooklyn catalog